### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If you use this tool in other scripts where the output is saved everywhere, not 
 
 ### Limitations
 
-- each **TOR**, **http-proxy** and **HAProxy** processes needs a certain number of memory. If the number of **TOR** processes is too big, the oldest one will be automatic killed by the system
+- each **TOR**, **http-proxy** and **HAProxy** processes needs a certain number of memory. If the number of **TOR** processes is too big, the oldest one will be automatically killed by the system
 - **Polipo** is no longer supported but it is still a very good and light proxy. In my opinion the best http-proxy solution is **Privoxy**
 - I think this topic will be usefull for You before using **multitor** - [How to run multiple Tor processes at once with different exit IPs?](https://stackoverflow.com/questions/14321214/how-to-run-multiple-tor-processes-at-once-with-different-exit-ips)
 


### PR DESCRIPTION
I think we need the adverb `automatically` in the sentence (see https://en.oxforddictionaries.com/definition/automatic, https://en.oxforddictionaries.com/definition/automatically).