### PR TITLE
Fixed error with tor password hashing output being corrupted with logs.

### DIFF
--- a/src/__init__
+++ b/src/__init__
@@ -523,7 +523,7 @@ function __main__() {
     # shellcheck disable=SC2034
     _pass_gen=$(< /dev/urandom tr -dc 'a-zA-Z0-9' | fold -w 18 | head -n 1)
     # shellcheck disable=SC2034
-    _pass_hash=$(sudo -u "$user_name" tor --hash-password "$_pass_gen" | grep "16:")
+    _pass_hash=$(sudo -u "$user_name" tor --hash-password "$_pass_gen" --quiet | grep "16:[0-9A-Z]*")
 
     if [[ "$proxy_state" -eq 1 ]] ; then
 


### PR DESCRIPTION
There is a bug in hashing procedure for tor password.

If "tor --hash-password" produces any logs than log line could be included as generated hash. After that tor config (*.torrc) would be corrupted with log line and tor processes would not be able to start.

To reproduce bug you should run multitor with "--user root". Than you will get warning from "tor". If warning line includes "16:" string in log date/time than tor service will be unable to start.

Example:
`bash-5.1# sudo -u "root" tor --hash-password "$_pass_gen"              
Jul 24 16:58:42.380 [warn] You are running Tor as root. You don't need to, and you probably shouldn't.
16:6D4B63B753752091118087E9FA55DBB055FA9CA746299B7AFD1BBEE9F4`

As solution i suggest to add --quiet option to prevent "tor --hash-password" to log any warnings as it's not written anywhere. There is also improved grep regex that would not match time that includes "16:".
